### PR TITLE
fix: Added ``default_auto_field`` to app config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,4 +6,5 @@ Changelog
 0.1.0 (unreleased)
 ==================
 
+* Set ``default_auto_field`` to ``BigAutoField`` to ensure projects don't try to create a migration if they still use ``AutoField``
 * Transfer of forms app from djangocms-frontend

--- a/djangocms_form_builder/apps.py
+++ b/djangocms_form_builder/apps.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class FormsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "djangocms_form_builder"
     verbose_name = _("django CMS form builder")
 


### PR DESCRIPTION
Set ``default_auto_field`` to ``BigAutoField`` to ensure projects don't try to create a migration if they still use ``AutoField``