### PR TITLE
chore: Added venv/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 dist/
 env/
 .venv/
+venv/
 
 /~
 /node_modules


### PR DESCRIPTION
venv/ is a pretty popular directory used in many python projects, a lot of docs just use venv as the directory to hold the virtualenv created by the venv module. It makes sense to add this to .gitignore.