### PR TITLE
feat: Add required class to form widget div attributes

### DIFF
--- a/djangocms_form_builder/templatetags/form_builder_tags.py
+++ b/djangocms_form_builder/templatetags/form_builder_tags.py
@@ -105,6 +105,8 @@ def render_widget(form, form_field, **kwargs):
         if input_type not in ("checkbox", "radio"):
             field_sep += " form-floating"  # TODO: Only true for Bootstrap5
     div_attrs = attrs_for_widget(field.field.widget, "div", field_sep)
+    if field.field.required:
+        div_attrs["class"] = div_attrs.get("class", "") + " required"
     div_attrs = " ".join([f'{key}="{value}"' for key, value in div_attrs.items()])
     grp_attrs = attrs_for_widget(field.field.widget, "group")
     errors = "".join(


### PR DESCRIPTION
Hello,

It would be super useful to have a "required" class added to the fields that are required so we can add a * or bold or whatever in css when displaying the field.

Do you think this PR is relevant ? 

Thank you :)

## Summary by Sourcery

New Features:
- Add "required" CSS class to the form widget's div when the field is required