### PR TITLE
fix: Strip email subject to remove new lines chars

### DIFF
--- a/djangocms_form_builder/actions.py
+++ b/djangocms_form_builder/actions.py
@@ -215,7 +215,7 @@ class SendMailAction(FormAction):
             subject = render_to_string(
                 f"djangocms_form_builder/mails/{template_set}/subject.txt", context
             )
-            # Strip begin and final new lines
+            # Strip beginning and ending new lines
             subject = subject.strip()
         except TemplateDoesNotExist:
             subject = self.subject % dict(form_name=context["form_name"])


### PR DESCRIPTION
When email template `subject.txt` is overridden, there is a high probability that  the overridden template contains unwanted newlines at the start or end of the file:

- At the start, if you load a template tag (ex: `{% load i18n %}`)
- At the end, if your text editor has such config (ex : insert_final_newline = true)

Example of subject.txt template : 

```
{% load i18n %}
{% translate "New contact request" %}

```

In this case, Django raises an error while sending the mail : 

  ```
File ".../.venv/lib/python3.13/site-packages/django/core/mail/message.py", line 61, in forbid_multi_line_headers
    raise BadHeaderError(
        "Header values can't contain newlines (got %r for header %r)" % (val, name)
    )
```

Solution: the subject must be stripped of newlines before calling the send_mail function.

## Summary by Sourcery

Bug Fixes:
- Remove leading and trailing newlines from email subject before sending