### PR TITLE
fix: GET form endpoint caused a server error

### DIFF
--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.http import Http404, JsonResponse
+from django.http import Http404, HttpResponseNotAllowed, JsonResponse
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
@@ -27,7 +27,7 @@ class CMSAjaxBase(CMSPluginBase):
         return JsonResponse({})
 
     def ajax_get(self, request, instance, parameter):
-        return JsonResponse({})
+        return HttpResponseNotAllowed(["POST"])
 
 
 class AjaxFormMixin(FormMixin):
@@ -195,32 +195,6 @@ class AjaxFormMixin(FormMixin):
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
-
-    def ajax_get(self, request, instance, parameter=None):
-        if parameter is None:
-            parameter = {}
-        self.request = request
-        self.instance = instance
-        self.parameter = parameter
-        context = self.get_context_data(**parameter)
-        errors, redirect, content = (
-            [],
-            "",
-            render_to_string(self.template_name, context.flatten(), self.request),
-        )
-        return JsonResponse(
-            {
-                "result": (
-                    ("result" if redirect == "result" else "success")
-                    if errors == []
-                    else "error"
-                ),
-                "redirect": redirect,
-                "errors": errors,
-                "field_errors": {},
-                "content": content,
-            }
-        )
 
 
 class CMSAjaxForm(AjaxFormMixin, CMSAjaxBase):

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -75,7 +75,14 @@ class AjaxView(View):
 
     @staticmethod
     def plugin_instance(pk):
-        plugin = get_object_or_404(CMSPlugin, pk=pk)
+        try:
+            plugin = CMSPlugin.objects.select_related(
+                "placeholder", "placeholder__content_type"
+            ).get(pk=pk)
+        except CMSPlugin.DoesNotExist:
+            raise Http404
+        source_model = plugin.placeholder.content_type.model_class()
+        get_object_or_404(source_model, pk=plugin.placeholder.object_id)
         plugin.__class__ = plugin.get_plugin_class()
         instance = (
             plugin.model.objects.get(cmsplugin_ptr=plugin.id)

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -81,14 +81,19 @@ class AjaxView(View):
         return params
 
     @staticmethod
-    def plugin_instance(pk):
+    def plugin_instance(pk, admin_user):
         try:
             plugin = CMSPlugin.objects.select_related(*SELECT_RELATED).get(pk=pk)
         except CMSPlugin.DoesNotExist:
             raise Http404
         if "placeholder__content_type" in SELECT_RELATED:
             source_model = plugin.placeholder.content_type.model_class()
-            get_object_or_404(source_model, pk=plugin.placeholder.object_id)
+            if admin_user and hasattr(source_model, "admin_manager"):
+                get_object_or_404(
+                    source_model.admin_manager, pk=plugin.placeholder.object_id
+                )
+            else:
+                get_object_or_404(source_model, pk=plugin.placeholder.object_id)
         plugin.__class__ = plugin.get_plugin_class()
         instance = (
             plugin.model.objects.get(cmsplugin_ptr=plugin.id)
@@ -125,7 +130,9 @@ class AjaxView(View):
                              processing.
         """
         if "instance_id" in kwargs:
-            plugin, instance = self.plugin_instance(kwargs["instance_id"])
+            plugin, instance = self.plugin_instance(
+                kwargs["instance_id"], admin_user=request.user.is_staff
+            )
             if hasattr(plugin, "ajax_post"):
                 request.POST = QueryDict(request.body)
                 try:

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from cms import __version__ as cms_version
 from cms.models import CMSPlugin
 from django.core.exceptions import ValidationError
 from django.http import Http404, JsonResponse, QueryDict
@@ -9,6 +10,12 @@ from django.utils.translation import gettext as _
 from django.views import View
 
 _formview_pool = {}
+
+
+if cms_version < "4":
+    SELECT_RELATED = ("placeholder",)
+else:
+    SELECT_RELATED = ("placeholder", "placeholder__content_type")
 
 
 def register_form_view(cls, slug=None):
@@ -76,13 +83,12 @@ class AjaxView(View):
     @staticmethod
     def plugin_instance(pk):
         try:
-            plugin = CMSPlugin.objects.select_related(
-                "placeholder", "placeholder__content_type"
-            ).get(pk=pk)
+            plugin = CMSPlugin.objects.select_related(*SELECT_RELATED).get(pk=pk)
         except CMSPlugin.DoesNotExist:
             raise Http404
-        source_model = plugin.placeholder.content_type.model_class()
-        get_object_or_404(source_model, pk=plugin.placeholder.object_id)
+        if "placeholder__content_type" in SELECT_RELATED:
+            source_model = plugin.placeholder.content_type.model_class()
+            get_object_or_404(source_model, pk=plugin.placeholder.object_id)
         plugin.__class__ = plugin.get_plugin_class()
         instance = (
             plugin.model.objects.get(cmsplugin_ptr=plugin.id)

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -183,7 +183,9 @@ class AjaxView(View):
               the `_formview_pool` and calls its `ajax_get` or `get` method if available.
         """
         if "instance_id" in kwargs:
-            plugin, instance = self.plugin_instance(kwargs["instance_id"])
+            plugin, instance = self.plugin_instance(
+                kwargs["instance_id"], admin_user=request.user.is_staff
+            )
             if hasattr(plugin, "ajax_get"):
                 request.GET = QueryDict(request.body)
                 try:

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -1,5 +1,6 @@
 import json
 from unittest import mock, skipIf
+from urllib.parse import urlencode
 
 from cms import __version__ as cms_version
 from cms.api import add_plugin
@@ -472,11 +473,65 @@ class RegisterFormViewTestCase(CMSTestCase):
 class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
     """Tests for AJAX GET requests"""
 
+    def _create_simple_form_plugin(self, form_name="simple-ajax-form"):
+        form_plugin = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.FormPlugin.__name__,
+            language=self.language,
+            form_selection="",
+            form_name=form_name,
+            captcha_widget="",
+        )
+
+        char_field = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.CharFieldPlugin.__name__,
+            target=form_plugin,
+            language=self.language,
+            config={
+                "field_name": "simple_field",
+                "field_label": "Simple Field",
+                "field_required": True,
+            },
+        )
+        char_field.initialize_from_form()
+        return form_plugin
+
+    @skipIf(cms_version < "4", "Form rendering tests require django CMS 4 or higher")
     def test_ajax_get_returns_form_content(self):
-        """Test that AJAX GET request returns form content"""
-        # Skip this test as GET requests need special handling in the plugin
-        # The ajax_get method requires get_context_data which needs proper setup
-        self.skipTest("AJAX GET requires more complex setup with context data")
+        """Test that AJAX GET request is rejected with HTTP 405"""
+        form_plugin = self._create_simple_form_plugin("simple-ajax-get")
+        self.publish(self.page, self.language)
+
+        url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(url, headers={"accept": "application/json"})
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_ajax_post_simple_form_submission(self):
+        """Test that AJAX POST submits a simple form plugin"""
+        form_plugin = self._create_simple_form_plugin("simple-ajax-post")
+        self.publish(self.page, self.language)
+
+        url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
+
+        with self.login_user_context(self.superuser):
+            response = self.client.post(
+                url,
+                data=urlencode({"simple_field": "posted value"}),
+                content_type="application/x-www-form-urlencoded",
+                headers={"accept": "application/json"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, JsonResponse)
+
+        json_data = response.json()
+        self.assertIn("result", json_data)
+        self.assertIn(json_data["result"], ["success", "error"])
+        self.assertIn("field_errors", json_data)
 
 
 @skipIf(cms_version < "4", "Form plugin tests require django CMS 4 or higher")

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
-from django.http import JsonResponse
+from django.http import HttpResponseNotAllowed, JsonResponse
 from django.test import RequestFactory
 from django.urls import reverse
 
@@ -503,7 +503,7 @@ class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
         self.publish(self.page, self.language)
 
         url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
-        response = self.client.get(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        response = self.client.get(url, headers={"x-requested-with": "XMLHttpRequest"})
 
         self.assertEqual(response.status_code, 405)
         self.assertIsInstance(response, HttpResponseNotAllowed)

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -497,18 +497,17 @@ class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
         char_field.initialize_from_form()
         return form_plugin
 
-    @skipIf(cms_version < "4", "Form rendering tests require django CMS 4 or higher")
     def test_ajax_get_returns_form_content(self):
         """Test that AJAX GET request is rejected with HTTP 405"""
         form_plugin = self._create_simple_form_plugin("simple-ajax-get")
         self.publish(self.page, self.language)
 
         url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
-
-        with self.login_user_context(self.superuser):
-            response = self.client.get(url, headers={"accept": "application/json"})
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
 
         self.assertEqual(response.status_code, 405)
+        self.assertIsInstance(response, HttpResponseNotAllowed)
+        self.assertEqual(response["Allow"], "POST")
 
     def test_ajax_post_simple_form_submission(self):
         """Test that AJAX POST submits a simple form plugin"""

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -54,7 +54,7 @@ class AjaxViewTestCase(TestFixture, CMSTestCase):
             form_name="test-form",
         )
 
-        plugin, instance = AjaxView.plugin_instance(form_plugin.pk)
+        plugin, instance = AjaxView.plugin_instance(form_plugin.pk, admin_user=True)
 
         self.assertIsNotNone(plugin)
         self.assertIsNotNone(instance)
@@ -66,7 +66,7 @@ class AjaxViewTestCase(TestFixture, CMSTestCase):
         from django.http import Http404
 
         with self.assertRaises(Http404):
-            AjaxView.plugin_instance(99999)
+            AjaxView.plugin_instance(99999, admin_user=True)
 
     @skipIf(cms_version < "4", "Form rendering tests require django CMS 4 or higher")
     def test_dispatch_with_json_accept_header_post(self):


### PR DESCRIPTION
## Summary by Sourcery

Handle AJAX form GET requests correctly and verify AJAX form submission flows.

Bug Fixes:
- Reject AJAX GET requests to the form endpoint with HTTP 405 instead of causing a server error.

Tests:
- Add AJAX GET test that asserts the form endpoint returns HTTP 405 for GET requests.
- Add AJAX POST integration test that submits a simple form plugin and validates the JSON response structure.

fixes #46 