### PR TITLE
fix: Remove context print on ajax form when form is valid

### DIFF
--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -84,7 +84,7 @@ class AjaxFormMixin(FormMixin):
             if hasattr(form, get_success_context):
                 get_success_context = getattr(form, get_success_context)
                 context.update(get_success_context(self.request, self.instance, form))
-            print(context)
+
             errors, result, redir, content = (
                 [],
                 context.get("result", "success"),


### PR DESCRIPTION
Just a one-line change, but I’ve identified a print statement in `AjaxFormMixin.form_valid` that logs the posted data to the console and potentially to the server logs.

## Summary by Sourcery

Bug Fixes:
- Stop printing AJAX form context data to stdout/server logs when the form is valid to avoid leaking posted data.