### PR TITLE
fix: FormPlugin should never be in cache

### DIFF
--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -270,6 +270,7 @@ class FormPlugin(ActionMixin, CMSAjaxForm):
     render_template = f"djangocms_form_builder/{settings.framework}/form.html"
     change_form_template = "djangocms_frontend/admin/base.html"
     allow_children = True
+    cache = False
 
     fieldsets = [
         (


### PR DESCRIPTION
I've encountered issues in production with the `FormPlugin` being set in cache.

This plugin should never be cached because it caches the csrf token and then prevent the form from being posted. 

To reproduce the issue : 

- Activate CACHE on the CMS content : 

```
CMS_CACHE_DURATIONS = {
    "menus": 3600,
    "content": 3600,
    "permissions": 3600,
}
```

- Empty your cache
- With one browser session, go to the page containing your form
- With another browser session, go to the page containing your form and try to post it

<img width="964" height="386" alt="image" src="https://github.com/user-attachments/assets/7b8fce84-1fdf-4096-92c1-23351878f6ef" />

Not caching the plugin at all solves the issue.

## Summary by Sourcery

Bug Fixes:
- Prevent FormPlugin instances from being cached so that CSRF tokens remain valid across sessions when CMS content caching is enabled.