### PR TITLE
chore: Prepare release 0.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+0.5.1 (2026-06-01)
+==================
+
+* feat: Allow caching of form plugin by @fsbraun in https://github.com/django-cms/djangocms-form-builder/pull/52
+* feat: Add Altcha CAPTCHA support by @pierreben in https://github.com/django-cms/djangocms-form-builder/pull/43
+* fix: Remove context print on ajax form when form is valid by @pierreben in https://github.com/django-cms/djangocms-form-builder/pull/48
+* fix: GET form endpoint caused a server error by @fsbraun in https://github.com/django-cms/djangocms-form-builder/pull/47
+* fix: FormPlugin should never be in cache by @pierreben in https://github.com/django-cms/djangocms-form-builder/pull/50
+* fix: Anonymous users not detected correctly in mail_html.html by @svandeneertwegh in https://github.com/django-cms/djangocms-form-builder/pull/54
+* docs: Update django-altcha related docs and version requirement after… by @pierreben in https://github.com/django-cms/djangocms-form-builder/pull/49
+
+**New Contributors**
+
+* @vinitkumar made their first contribution in https://github.com/django-cms/djangocms-form-builder/pull/45
+
+
 0.5.0 (2026-03-09)
 ==================
 

--- a/djangocms_form_builder/__init__.py
+++ b/djangocms_form_builder/__init__.py
@@ -6,7 +6,7 @@ except ModuleNotFoundError:
     _ = lambda x: x  # noqa: E731
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 _form_registry = {}
 


### PR DESCRIPTION
## Summary by Sourcery

Prepare the project for the 0.5.1 release.

Enhancements:
- Bump the package version from 0.5.0 to 0.5.1 in the core module.

Documentation:
- Update the changelog for the 0.5.1 release.