### PR TITLE
fix: Enforce min/max length on CharField and TextareaField (#53)

### DIFF
--- a/djangocms_form_builder/helpers.py
+++ b/djangocms_form_builder/helpers.py
@@ -136,3 +136,10 @@ def coerce_decimal(value):
         return decimal.Decimal(value)
     except TypeError:
         return None
+
+
+def coerce_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/djangocms_form_builder/models.py
+++ b/djangocms_form_builder/models.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from . import recaptcha, settings
 from .entry_model import FormEntry  # NoQA
 from .fields import AttributesField
-from .helpers import coerce_decimal, mark_safe_lazy
+from .helpers import coerce_decimal, coerce_int, mark_safe_lazy
 
 MAX_LENGTH = 256
 
@@ -205,6 +205,8 @@ class CharField(FormField):
             label=self.config.get("field_label", ""),
             required=self.config.get("field_required", False),
             help_text=self.config.get("field_help_text", ""),
+            min_length=coerce_int(self.config.get("min_length", None)),
+            max_length=coerce_int(self.config.get("max_length", None)),
             widget=forms.TextInput(
                 attrs=dict(placeholder=self.config.get("field_placeholder", ""))
             ),
@@ -314,6 +316,8 @@ class TextareaField(FormField):
             label=self.config.get("field_label", ""),
             required=self.config.get("field_required", False),
             help_text=self.config.get("field_help_text", ""),
+            min_length=coerce_int(self.config.get("min_length", None)),
+            max_length=coerce_int(self.config.get("max_length", None)),
             widget=forms.Textarea(
                 attrs=dict(
                     rows=self.config.get("field_rows", 10),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -371,6 +371,44 @@ class TextareaFieldModelTests(TestFixture, CMSTestCase):
         self.assertEqual(form_field.help_text, "Share any additional details.")
         self.assertEqual(form_field.widget.attrs["rows"], 5)
 
+    def test_textareafield_min_max_length_validation(self):
+        """min_length/max_length config is enforced by the generated field"""
+        field = TextareaField.objects.create(
+            placeholder=self.placeholder,
+            language=self.language,
+            config={
+                "field_name": "comments",
+                "field_label": "Comments",
+                "min_length": 3,
+                "max_length": 8,
+            },
+        )
+        _, form_field = field.get_form_field()
+
+        self.assertEqual(form_field.min_length, 3)
+        self.assertEqual(form_field.max_length, 8)
+        # HTML attributes are set for client-side hinting
+        self.assertEqual(str(form_field.widget.attrs["minlength"]), "3")
+        self.assertEqual(str(form_field.widget.attrs["maxlength"]), "8")
+        # Server-side validation
+        with self.assertRaises(forms.ValidationError):
+            form_field.clean("ab")
+        with self.assertRaises(forms.ValidationError):
+            form_field.clean("abcdefghi")
+        self.assertEqual(form_field.clean("abcd"), "abcd")
+
+    def test_textareafield_without_min_max_length(self):
+        """Missing min_length/max_length config does not add validators"""
+        field = TextareaField.objects.create(
+            placeholder=self.placeholder,
+            language=self.language,
+            config={"field_name": "comments"},
+        )
+        _, form_field = field.get_form_field()
+
+        self.assertIsNone(form_field.min_length)
+        self.assertIsNone(form_field.max_length)
+
 
 class DateFieldModelTests(TestFixture, CMSTestCase):
     """Test DateField model"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -191,6 +191,44 @@ class CharFieldModelTests(TestFixture, CMSTestCase):
         self.assertEqual(form_field.help_text, "Pick a unique username.")
         self.assertEqual(form_field.widget.attrs["placeholder"], "Enter username")
 
+    def test_charfield_min_max_length_validation(self):
+        """min_length/max_length config is enforced by the generated field"""
+        field = CharField.objects.create(
+            placeholder=self.placeholder,
+            language=self.language,
+            config={
+                "field_name": "username",
+                "field_label": "Username",
+                "min_length": 3,
+                "max_length": 8,
+            },
+        )
+        _, form_field = field.get_form_field()
+
+        self.assertEqual(form_field.min_length, 3)
+        self.assertEqual(form_field.max_length, 8)
+        # HTML attributes are set for client-side hinting
+        self.assertEqual(str(form_field.widget.attrs["minlength"]), "3")
+        self.assertEqual(str(form_field.widget.attrs["maxlength"]), "8")
+        # Server-side validation
+        with self.assertRaises(forms.ValidationError):
+            form_field.clean("ab")
+        with self.assertRaises(forms.ValidationError):
+            form_field.clean("abcdefghi")
+        self.assertEqual(form_field.clean("abcd"), "abcd")
+
+    def test_charfield_without_min_max_length(self):
+        """Missing min_length/max_length config does not add validators"""
+        field = CharField.objects.create(
+            placeholder=self.placeholder,
+            language=self.language,
+            config={"field_name": "username"},
+        )
+        _, form_field = field.get_form_field()
+
+        self.assertIsNone(form_field.min_length)
+        self.assertIsNone(form_field.max_length)
+
 
 class EmailFieldModelTests(TestFixture, CMSTestCase):
     """Test EmailField model"""


### PR DESCRIPTION

## Summary by Sourcery

Enforce configured minimum and maximum length constraints on CharField and TextareaField form fields.

Bug Fixes:
- Apply configured min_length and max_length values to generated CharField and TextareaField form fields so they are validated server-side and reflected in HTML attributes.

Enhancements:
- Introduce a coerce_int helper to safely convert optional length configuration values to integers.

Tests:
- Add tests verifying that min_length/max_length constraints are enforced when configured and omitted when not set for CharField form fields.


* Fixes #53
